### PR TITLE
Version 0.3.x [BREAKING CHANGES]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,24 +13,6 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 
-class VerifyVersionCommand(install):
-    """Custom command to verify that the git tag matches our version"""
-
-    description = "verify that the git tag matches our version"
-
-    def run(self):
-        tag = os.getenv("CIRCLE_TAG")
-
-        if tag == None:
-            info = "No new version to upload"
-            print(info)
-        elif tag != VERSION:
-            info = "Git tag: {0} does not match the version of this app: {1}".format(
-                tag, VERSION
-            )
-            sys.exit(info)
-
-
 setuptools.setup(
     name="geotiff",
     version=VERSION,
@@ -53,7 +35,5 @@ setuptools.setup(
         "pyproj",
         "zarr",
     ],
-    cmdclass={
-        "verify": VerifyVersionCommand,
-    },
+    cmdclass={},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-import setuptools # type: ignore
+import setuptools  # type: ignore
 import os
 import sys
-from setuptools.command.install import install # type: ignore
+from setuptools.command.install import install  # type: ignore
 
-VERSION = "0.2.3"
+VERSION = "0.3a1"
 
 # Send to pypi
 # python3 setup.py sdist bdist_wheel
@@ -12,12 +12,14 @@ VERSION = "0.2.3"
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
+
 class VerifyVersionCommand(install):
     """Custom command to verify that the git tag matches our version"""
-    description = 'verify that the git tag matches our version'
+
+    description = "verify that the git tag matches our version"
 
     def run(self):
-        tag = os.getenv('CIRCLE_TAG')
+        tag = os.getenv("CIRCLE_TAG")
 
         if tag == None:
             info = "No new version to upload"
@@ -27,6 +29,7 @@ class VerifyVersionCommand(install):
                 tag, VERSION
             )
             sys.exit(info)
+
 
 setuptools.setup(
     name="geotiff",
@@ -43,14 +46,14 @@ setuptools.setup(
         "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.7',
+    python_requires=">=3.7",
     install_requires=[
-        'tifffile==2021.7.2',
-        'numpy',
-        'pyproj',
-        'zarr',
+        "tifffile==2021.7.2",
+        "numpy",
+        "pyproj",
+        "zarr",
     ],
     cmdclass={
-        'verify': VerifyVersionCommand,
-    }
+        "verify": VerifyVersionCommand,
+    },
 )


### PR DESCRIPTION
This PR will have breaking changes to allow the distributed (pickeling) of the classes and methods in this package.

Specifically, it will remove the integration of `PyPorj` for transforming coordinates and instead will allow the passing of a transform function as a param in the `GeoTiff` constructor. Something like:

```python
from pyproj import Transformer
from geotiff import GeoTiff


transformer = Transformer.from_crs(4326, 7844, always_xy=True)

geo_tiff = GeoTiff(tiff_file, crs_code=4326, transformer=transformer)
```

