### PR TITLE
Tifffile fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tifffile>=2021.7.2
+tifffile>=2021.7.2, <2022.4.28
 numpy
 pyproj
 zarr>=2.10.*

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup  # type: ignore
 from setuptools.command.egg_info import egg_info  # type: ignore
 from setuptools.command.install import install  # type: ignore
 
-VERSION = "0.2.6"
+VERSION = "0.2.7"
 
 # Send to pypi
 # python3 setup.py sdist bdist_wheel


### PR DESCRIPTION
This PR fixed the issue that is caused by a breaking change in `tifffile` as mentioned in #50:
- [restrict tifffile <2022.4.28](https://github.com/KipCrossing/geotiff/commit/60da1379b00a26adc5f39334ca286d8bb6a68f2f) (rolling releases and breaking changes don't mix lol)
- It also [bumps the version](https://github.com/KipCrossing/geotiff/commit/ea81c840e0c5c07f19a9e40f50acbaa8085abc30) to include the fix. 

