### PR TITLE
WIP: Speedup get_coord_arrays

### DIFF
--- a/geotiff/geotiff.py
+++ b/geotiff/geotiff.py
@@ -126,7 +126,6 @@ class TifTransformer:
                 np.zeros(i_array.size, dtype=int),
                 np.ones(j_array.size, dtype=int),
             ),
-            dtype=int,
         )
         xy = np.dot(transforms, vecs)
         return xy[0, 0, :], xy[0, 1, :]


### PR DESCRIPTION
Hi,

this PR should speed up the `GeoTiff.get_coord_arrays` method by several orders of magnitude for any larger array.

The previous implementation spent a lot of time, calling `TifTransformer.get_xy` for every grid node seperately. Solved by adding a method `TifTransformer.get_xy_array` to do the transform for all requested nodes in a single shot and letting numpy do the looping.

Sorry, I couldn't run pre-commit locally because it fails when setting up the various dependencies with pip. I cannot investigate the reason due to time constraints.

The proposed changes break some internal interfaces (`_convert_coords_array` now takes arrays instead of lists), therefore I label this as WIP. Please check if this is a problem.

Best wishes
Sebastian
