### PR TITLE
fix invalid zarr packaging requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tifffile>=2021.7.2,<2022.4.28
 numpy
 pyproj
-zarr>=2.10.*
+zarr>=2.10.0


### PR DESCRIPTION
## Detail

When installing `geotiff` since this change: https://github.com/KipCrossing/geotiff/commit/ef74e5805de8729d9c9f2d212fc4c554693a92d3 (>= https://github.com/KipCrossing/geotiff/releases/tag/0.2.6)
The following error is generated. 

```
Traceback (most recent call last):
  File "/home/dev/.conda/envs/weaver/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3039, in _dep_map
    return self.__dep_map
  File "/home/dev/.conda/envs/weaver/lib/python3.9/site-packages/pkg_resources/__init__.py", line 2835, in __getattr__
    raise AttributeError(attr)
AttributeError: _DistInfoDistribution__dep_map

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dev/.conda/envs/weaver/lib/python3.9/site-packages/pkg_resources/_vendor/packaging/requirements.py", line 35, in __init__
    parsed = parse_requirement(requirement_string)
  File "/home/dev/.conda/envs/weaver/lib/python3.9/site-packages/pkg_resources/_vendor/packaging/_parser.py", line 64, in parse_requirement
    return _parse_requirement(Tokenizer(source, rules=DEFAULT_RULES))
  File "/home/dev/.conda/envs/weaver/lib/python3.9/site-packages/pkg_resources/_vendor/packaging/_parser.py", line 82, in _parse_requirement
    url, specifier, marker = _parse_requirement_details(tokenizer)
  File "/home/dev/.conda/envs/weaver/lib/python3.9/site-packages/pkg_resources/_vendor/packaging/_parser.py", line 120, in _parse_requirement_details
    specifier = _parse_specifier(tokenizer)
  File "/home/dev/.conda/envs/weaver/lib/python3.9/site-packages/pkg_resources/_vendor/packaging/_parser.py", line 209, in _parse_specifier
    tokenizer.consume("WS")
  File "/home/dev/.conda/envs/weaver/lib/python3.9/contextlib.py", line 126, in __exit__
    next(self.gen)
  File "/home/dev/.conda/envs/weaver/lib/python3.9/site-packages/pkg_resources/_vendor/packaging/_tokenizer.py", line 183, in enclosing_tokens
    self.raise_syntax_error(
  File "/home/dev/.conda/envs/weaver/lib/python3.9/site-packages/pkg_resources/_vendor/packaging/_tokenizer.py", line 163, in raise_syntax_error
    raise ParserSyntaxError(
pkg_resources.extern.packaging._tokenizer.ParserSyntaxError: Expected closing RIGHT_PARENTHESIS
    zarr (>=2.10.*)
         ~~~~~~~^
```

This is because the use of `.*` is only valid when combined with `==` or `!=` (which was fine before), but is now invalid with `>=` (though some tools will allow it silently).

https://peps.python.org/pep-0440/#inclusive-ordered-comparison indicates that the version is zero-padded for doing `>=` comparison against other versions, so `>=2.10` or `>=2.10.0` should be equivalent, and there shouldn't be any lower version than `PATCH=0`. 

## Relevant references: 
- https://github.com/pypa/packaging/issues/566
- https://github.com/pypa/packaging/issues/657
- https://github.com/pypa/packaging/issues/673

## Affected Packages (not exhaustive)
- https://github.com/geopython/pywps and any derived application


FYI @Zeitsperre @f-PLT


