### PR TITLE
Breaking change with new zarr

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tifffile>=2021.7.2,<2022.4.28
 numpy
 pyproj
-zarr==2.14.*
+zarr==2.12.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tifffile>=2021.7.2,<2022.4.28
 numpy
 pyproj
-zarr==2.12.*
+zarr>=2.12.0,<2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tifffile>=2021.7.2,<2022.4.28
 numpy
 pyproj
-zarr>=2.10.0
+zarr==2.14.*

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup  # type: ignore
 from setuptools.command.egg_info import egg_info  # type: ignore
 from setuptools.command.install import install  # type: ignore
 
-VERSION = "0.2.9"
+VERSION = "0.2.10"
 
 # Send to pypi
 # python3 setup.py sdist bdist_wheel


### PR DESCRIPTION
Closes #63

For now, just lock `zarr` to an older/comparable version 