### PR TITLE
Docstring adjustments and pre-commit update, support Python3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,34 +5,45 @@ name: Python package
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
 jobs:
-  build:
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - uses: pre-commit/action@v3.0.0
+
+  build:
+    needs: lint
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8','3.9']
-
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest
-        python -m pip install mypy
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Test with pytest
-      run: |
-        python -m pytest -s
-    - name: Check typing with mypy
-      run: |
-        mypy geotiff
-        mypy setup.py
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install mypy
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Test with pytest
+        run: |
+          python -m pytest -s
+      - name: Check typing with mypy
+        run: |
+          mypy geotiff
+          mypy setup.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: yesqa
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.5.1
     hooks:
       - id: mypy
   - repo: https://github.com/psf/black
@@ -53,7 +53,7 @@ repos:
     hooks:
       - id: check-manifest
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.23.3
+    rev: 0.24.1
     hooks:
       - id: check-github-workflows
   - repo: meta

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,55 +3,59 @@ default_language_version:
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.1
+    rev: v3.10.1
     hooks:
       - id: pyupgrade
         args: [ "--py37-plus" ]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
         exclude: setup.cfg
       - id: end-of-file-fixer
       - id: debug-statements
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.5.0
+    hooks:
+      - id: yesqa
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v1.4.1
     hooks:
       - id: mypy
-  - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-        args: [ '--config=setup.cfg' ]
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.7.0
     hooks:
       - id: black
         args: [ "--target-version=py37" ]
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        args: [ '--config=setup.cfg' ]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: [ "--settings-file=setup.cfg" ]
-# TODO: Requires significant changes
-#  - repo: https://github.com/pycqa/pydocstyle
-#    rev: 6.1.1
-#    hooks:
-#      - id: pydocstyle
-#        args: [ '--config=setup.cfg' ]
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
+        args: [ '--config=setup.cfg' ]
+        exclude: example.py
   - repo: https://github.com/keewis/blackdoc
-    rev: v0.3.4
+    rev: v0.3.8
     hooks:
       - id: blackdoc
-        additional_dependencies: [ 'black==22.6.0' ]
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.3.0
-    hooks:
-      - id: yesqa
+        additional_dependencies: [ 'black==23.7.0' ]
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.48"
+    rev: "0.49"
     hooks:
       - id: check-manifest
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.23.3
+    hooks:
+      - id: check-github-workflows
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 A noGDAL tool for reading geotiff files
 
-WARNING this package is under development and some features are unstable. Use with caution.
+> **Warning**
+> This package is under development and some features are unstable. Proceed with caution.
 
 Please support this project be giving it a [star on GitHub](https://github.com/Open-Source-Agriculture/geotiff)!
 
 ### What is noGDAL?
 
-**[noGDAL](https://kipling.medium.com/nogdal-e5b60b114a1c)** is a philosophy for developing geospatial programs in python without using GDAL.
+**[noGDAL](https://kipling.medium.com/nogdal-e5b60b114a1c)** is a philosophy for developing geospatial programs in Python without using GDAL.
 
 ### Installation
 
@@ -39,6 +40,7 @@ pip install -e .[dev]
 ```python
 from geotiff import GeoTiff
 
+tiff_file = "path/to/tiff/file"
 geo_tiff = GeoTiff(tiff_file)
 ```
 
@@ -59,7 +61,6 @@ Or you can use the original crs by setting `as_crs` to `None`:
 ```python
 geo_tiff = GeoTiff(tiff_file, as_crs=None)
 ```
-
 
 If the geotiff file has multiple bands, you can specify which band to use:
 
@@ -100,7 +101,7 @@ geo_tiff.get_wgs_84_coords(i, j)
 
 #### Read the data
 
-To read the data, use the `.read()` method. This will return a [zarr](https://zarr.readthedocs.io/en/stable/api/core.html) array as often geotiff files cannot fit into memory.
+To read the data, use the `.read()` method. This will return a [Zarr](https://zarr.readthedocs.io/en/stable/api/core.html) array as often geotiff files cannot fit into memory.
 
 ```python
 zarr_array = geo_tiff.read()
@@ -118,7 +119,8 @@ array = np.array(zarr_array)
 
 In many cases, you are only interested in a section of the tiff. For convenience, you can use the `.read_box()` method. This will return a numpy array.
 
-WARNING: This will fail if the box you are using is too large and the data cannot fit into memory.
+> **Warning**
+> This will fail if the box you are using is too large and the data cannot fit into memory.
 
 ```python
 from geotiff import GeoTiff
@@ -129,7 +131,8 @@ geo_tiff = GeoTiff(tiff_file)
 array = geo_tiff.read_box(area_box)
 ```
 
-*Note:* For the `area_box`, use the same crs as `as_crs`.
+> **Note**
+> For the `area_box`, use the same crs as `as_crs`.
 
 In some cases, you may want some extra points/pixels around the outside of your `area_box`. This may be useful if you want to interpolate to points near the area_box boundary. To achieve this, use the `outer_points` param:
 
@@ -188,14 +191,15 @@ lon_array, lat_array = geo_tiff.get_coord_arrays()
 
 If you would like to contribute to this project, please fork this repo and make a PR with your patches.
 
-You can join the conversation by saying hi in the [project discussion board](https://github.com/KipCrossing/geotiff/discussions).
+You can join the conversation by saying "hi" in the [project discussion board](https://github.com/KipCrossing/geotiff/discussions).
 
 To help users and other contributes, be sure to:
-- make doc blocs if appropriate
-- use typing wherever possible
-- format with black
+- Make docstrings and documentation blocks, if appropriate
+- Use Python typing wherever possible
+- Format your code with [Black](https://black.readthedocs.io/en/stable/index.html)
 
-*Note:* The continuous integration has lint checking with **mypy**, so be sure to check it yourself before making a PR.
+> **Note**
+> The continuous integration has lint checking with **mypy**, so be sure to check it yourself before making a PR.
 
 ### Project Road Map
 

--- a/example.py
+++ b/example.py
@@ -1,5 +1,4 @@
 import os
-from typing import Dict, List, Tuple
 
 import numpy as np  # type: ignore
 

--- a/geotiff/__init__.py
+++ b/geotiff/__init__.py
@@ -1,3 +1,4 @@
+"""A NoGDAL GeoTiff reader and writer."""
 __author__ = "Kipling Crossing"
 
 from .geotiff import GeoTiff, TifTransformer

--- a/geotiff/geotiff.py
+++ b/geotiff/geotiff.py
@@ -1,3 +1,4 @@
+"""GeoTIFF reader and writer."""
 from typing import List, Optional, Tuple, Union
 
 import numpy as np  # type: ignore
@@ -10,25 +11,37 @@ BBoxInt = Tuple[Tuple[int, int], Tuple[int, int]]
 
 
 class GeographicTypeGeoKeyError(Exception):
+    """Raised when the GeographicTypeGeoKey is not recognized."""
+
     def __str__(_):
+        """Return the error message."""
         return "Could not recognize the geo key\nPlease submit an issue: \
                 https://github.com/Open-Source-Agriculture/geotiff/issues"
 
 
 class UserDefinedGeoKeyError(Exception):
+    """Raised when the UserDefinedGeoKey is not supported."""
+
     def __str__(_):
-        return "user-defined GeoKeys are not yet supported"
+        """Return the error message."""
+        return "User-defined GeoKeys are not yet supported."
 
 
 class BoundaryNotInTifError(Exception):
+    """Raised when the boundary is not in the tiff file."""
+
     pass
 
 
 class FileTypeError(Exception):
+    """Raised when the file type is not supported."""
+
     pass
 
 
 class TifTransformer:
+    """Class that transforms coordinates from the geotiff file to lat/lon coordinates."""
+
     def __init__(
         self,
         height: int,
@@ -36,11 +49,11 @@ class TifTransformer:
         scale: Tuple[float, float, float],
         tiepoints: List[float],
     ):
-        """for transforming the coordinates of the geotiff file
+        """For transforming the coordinates of the geotiff file.
 
         Args:
-            height (int): Hight (y) of the geotiff array/file
-            width (int): Width of the geotiff array/file
+            height (int): Height (y) of the geotiff array/file.
+            width (int): Width of the geotiff array/file.
             scale (Tuple[float, float, float]): (sx, sy, sz) from ModelPixelScaleTag
             tiepoints (List[float]): [description]
         """
@@ -63,39 +76,39 @@ class TifTransformer:
         self.transforms: List[List[List[float]]] = transforms
 
     def get_x(self, i: int, j: int) -> float:
-        """Gets the x or lon coordinate based on the array index
+        """Gets the x or lon coordinate based on the array index.
 
         Args:
-            i (int): index in the x direction
-            j (int): index in the y direction
+            i (int): Index in the x direction.
+            j (int): Index in the y direction.
 
         Returns:
-            float: x or lon coordinate
+            float: x or lon coordinate.
         """
         transformed: List[float] = np.dot(self.transforms, [i, j, 0, 1]).tolist()[0]
         transformed_xy: List[float] = transformed[:2]
         return transformed_xy[0]
 
     def get_y(self, i: int, j: int) -> float:
-        """Gets the y or lat coordinate based on the array index
+        """Gets the y or lat coordinate based on the array index.
 
         Args:
-            i (int): index in the x direction
-            j (int): index in the y direction
+            i (int): Index in the x direction.
+            j (int): Index in the y direction.
 
         Returns:
-            float: y or lat coordinate
+            float: y or lat coordinate.
         """
         transformed: List[float] = np.dot(self.transforms, [i, j, 0, 1]).tolist()[0]
         transformed_xy: List[float] = transformed[:2]
         return transformed_xy[1]
 
     def get_xy(self, i: int, j: int) -> Tuple[float, float]:
-        """Gets the (x or lon) and (y or lat) coordinates based on the array index
+        """Gets the (x or lon) and (y or lat) coordinates based on the array index.
 
         Args:
-            i (int): index in the x direction
-            j (int): index in the y direction
+            i (int): Index in the x direction.
+            j (int): Index in the y direction.
 
         Returns:
             Tuple[float, float]: (x or lon) and (y or lat) coordinates
@@ -107,17 +120,15 @@ class TifTransformer:
     def get_xy_array(
         self, i_array: np.ndarray, j_array: np.ndarray
     ) -> Tuple[np.ndarray, np.ndarray]:
-
-        """Gets the (x or lon) and (y or lat) coordinates based on the array index (array version)
+        """Gets the (x or lon) and (y or lat) coordinates based on the array index (array version).
 
         Args:
-            i_array (np.ndarray): indices in the x direction
-            j_array (np.ndarray): indices in the y direction
+            i_array (np.ndarray): Indices in the x direction.
+            j_array (np.ndarray): Indices in the y direction.
 
         Returns:
-            Tuple[np.ndarray, np.ndarray]: (x or lon) and (y or lat) coordinates
+            Tuple[np.ndarray, np.ndarray]: (x or lon) and (y or lat) coordinates.
         """
-
         transforms = np.array(self.transforms, dtype=float)
         vecs = np.vstack(
             (
@@ -132,6 +143,8 @@ class TifTransformer:
 
 
 class GeoTiff:
+    """Class representing a geotiff object."""
+
     def __init__(
         self,
         file: str,
@@ -139,14 +152,14 @@ class GeoTiff:
         as_crs: Optional[int] = 4326,
         crs_code: Optional[int] = None,
     ):
-        """For representing a geotiff
+        """For representing a geotiff.
 
         Args:
-            file (str): Location of the geotiff file
+            file (str): Location of the geotiff file.
             band (int): The band of the tiff file to use. Defaults to 0.
-            as_crs (Optional[int]): The epsg crs code to read the data as.  Defaults to 4326 (WGS84).
-            crs_code (Optional[int]): The epsg crs code of the tiff file. Include this if the crs code can't be detected.
-
+            as_crs (Optional[int]): The epsg crs code to read the data as. Defaults to 4326 (WGS84).
+            crs_code (Optional[int]): The epsg crs code of the tiff file.
+              Include this if the crs code can't be detected.
         """
         self.file = file
         self._as_crs = crs_code if as_crs is None else as_crs
@@ -172,22 +185,27 @@ class GeoTiff:
 
     @property
     def crs_code(self):
+        """The epsg crs code of the tiff file."""
         return self._crs_code
 
     @property
     def as_crs(self):
+        """The epsg crs code to read the data as or to convert the data to."""
         return self._as_crs
 
     @property
     def tif_shape(self):
+        """The shape of the tiff file."""
         return self._tif_shape
 
     @property
     def tifTrans(self):
+        """The tif transformer object."""
         return self._tifTrans
 
     @property
     def tif_bBox(self):
+        """Returns the bounding box of the tiff in the native tiff coordinates."""
         return (
             self.tifTrans.get_xy(0, 0),
             self.tifTrans.get_xy(self.tif_shape[1], self.tif_shape[0]),
@@ -195,12 +213,14 @@ class GeoTiff:
 
     @property
     def tif_bBox_converted(self) -> BBox:
+        """Returns the bounding box of the tiff in the provided crs coordinates."""
         right_top = self._convert_coords(self.crs_code, self.as_crs, self.tif_bBox[0])
         left_bottom = self._convert_coords(self.crs_code, self.as_crs, self.tif_bBox[1])
         return (right_top, left_bottom)
 
     @property
     def tif_bBox_wgs_84(self) -> BBox:
+        """Returns the bounding box of the tiff in WGS84 coordinates."""
         right_top = self._convert_coords(self.crs_code, 4326, self.tif_bBox[0])
         left_bottom = self._convert_coords(self.crs_code, 4326, self.tif_bBox[1])
         return (right_top, left_bottom)
@@ -238,18 +258,18 @@ class GeoTiff:
         i_array: np.ndarray,
         j_array: np.ndarray,
     ):
-
         shape = (j_array.size, i_array.size)
-        ii, jj = [x.flatten() for x in np.meshgrid(i_array, j_array, indexing="xy")]
-        x_vals, y_vals = [x.reshape(shape) for x in self.tifTrans.get_xy_array(ii, jj)]
+        ii, jj = (x.flatten() for x in np.meshgrid(i_array, j_array, indexing="xy"))
+        x_vals, y_vals = (x.reshape(shape) for x in self.tifTrans.get_xy_array(ii, jj))
 
         from_crs_proj4 = CRS.from_epsg(from_crs_code)
         to_crs_proj4 = CRS.from_epsg(to_crs_code)
         transformer = Transformer.from_crs(from_crs_proj4, to_crs_proj4, always_xy=True)
         return transformer.transform(x_vals, y_vals)
 
+    @staticmethod
     def _convert_coords(
-        self, from_crs_code: int, to_crs_code: int, xxyy: Tuple[float, float]
+        from_crs_code: int, to_crs_code: int, xxyy: Tuple[float, float]
     ) -> Tuple[float, float]:
         xx, yy = xxyy
         from_crs_proj4 = CRS.from_epsg(from_crs_code)
@@ -268,29 +288,27 @@ class GeoTiff:
         return int(step_y * (lat - self.tif_bBox[0][1]))
 
     def get_coords(self, i: int, j: int) -> Tuple[float, float]:
-        """for a given i, j in the entire tiff array,
-        returns the as_crs coordinates
+        """For a given i, j in the entire tiff array, returns the as_crs coordinates.
 
         Args:
-            i (int): col number of the array
-            j (int): row number of the array
+            i (int): Column number of the array.
+            j (int): Row number of the array.
 
         Returns:
-            Tuple[float, float]: lon, lat
+            Tuple[float, float]: lon, lat.
         """
         x, y = self.tifTrans.get_xy(i, j)
         return self._convert_coords(self.crs_code, self.as_crs, (x, y))
 
     def get_wgs_84_coords(self, i: int, j: int) -> Tuple[float, float]:
-        """for a given i, j in the entire tiff array,
-        returns the wgs_84 coordinates
+        """For a given i, j in the entire tiff array, returns the wgs_84 coordinates.
 
         Args:
-            i (int): col number of the array
-            j (int): row number of the array
+            i (int): Column number of the array.
+            j (int): Row number of the array.
 
         Returns:
-            Tuple[float, float]: lon, lat
+            Tuple[float, float]: lon, lat.
         """
         x, y = self.tifTrans.get_xy(i, j)
         return self._convert_coords(self.crs_code, 4326, (x, y))
@@ -306,21 +324,20 @@ class GeoTiff:
     def get_int_box(
         self, bBox: BBox, outer_points: Union[bool, int] = False
     ) -> BBoxInt:
-        """Gets the intiger array index values based on a bounding box
+        """Gets the integer array index values based on a bounding box.
 
         Args:
-            bBox (BBox): A bounding box
-            outer_points (Union[bool, int]): Takes an int (n) that gets extra n layers of points/pixels that directly surround the bBox. Defaults to False.
+            bBox (BBox): A bounding box.
+            outer_points (Union[bool, int]): Takes an int (n) that gets extra n layers of points/pixels
+              that directly surround the bBox. Defaults to False.
 
         Raises:
-            BoundaryNotInTifError: If the boundary is not enclosed withing the
-                                    outer cooridinated of the tiff
+            BoundaryNotInTifError: If the boundary is not enclosed within the outer coordinates of the tiff.
 
         Returns:
-            BBoxInt: array index values
+            BBoxInt: Array index values.
         """
-
-        # all 4 corners  of box
+        # all 4 corners of box
         left_top = bBox[0]
         right_bottom = bBox[1]
         left_bottom = (bBox[0][0], bBox[1][1])
@@ -376,12 +393,12 @@ class GeoTiff:
     def get_bBox_wgs_84(
         self, bBox: BBox, outer_points: Union[bool, int] = False
     ) -> BBox:
-        """takes a bounding area gets the coordinates of the extremities
-        as if they were clipped by that bounding area
+        """Takes a bounding area gets the coordinates of the extremities as if they were clipped by that bounding area.
 
         Args:
-            bBox (BBox): bounding box area to clip within (wgs_84)
-            outer_points (Union[bool, int]): Takes an int (n) that gets extra n layers of points/pixels that directly surround the bBox. Defaults to False.
+            bBox (BBox): bounding box area to clip within (wgs_84).
+            outer_points (Union[bool, int]): Takes an int (n) that gets extra n layers of points/pixels
+              that directly surround the bBox. Defaults to False.
 
         Returns:
             BBox: in wgs_84
@@ -394,16 +411,17 @@ class GeoTiff:
     def get_coord_arrays(
         self, bBox: Optional[BBox] = None, outer_points: int = 0
     ) -> Tuple[np.ndarray, np.ndarray]:
-        """gets the 2d x coordinates and the 2d y coordinates
+        """Gets the 2d x coordinates and the 2d y coordinates.
 
-        WARNING: this cannot handel big arrays (zarr), so use with caution
+        WARNING: This cannot handel big arrays (zarr), so use with caution
 
         Args:
-            bBox (Optional[BBox], optional): The bounding box to git the coordinates within
-            outer_points (int, optional): Takes an int (n) that gets extra n layers of points/pixels that directly surround the bBox.
+            bBox (Optional[BBox], optional): The bounding box to git the coordinates within.
+            outer_points (int, optional): Takes an int (n) that gets extra n layers of points/pixels
+              that directly surround the bBox.
 
         Returns:
-            Tuple[np.ndarray, np.ndarray]: 2d x coordinates and the 2d y coordinates
+            Tuple[np.ndarray, np.ndarray]: 2d x coordinates and the 2d y coordinates.
         """
         if bBox is None:
             i_array = np.arange(self.tif_shape[1])
@@ -423,10 +441,10 @@ class GeoTiff:
         raise TypeError(f"You must supply a valid bBox. You gave: {bBox}")
 
     def read(self) -> zarr.Array:
-        """Reads the contents of the geotiff to a zarr array
+        """Reads the contents of the geotiff to a zarr array.
 
         Returns:
-            np.ndarray: zarr array of the geotiff file
+            np.ndarray: Zarr array of the geotiff file.
         """
         return self._z
 
@@ -436,17 +454,17 @@ class GeoTiff:
         outer_points: Union[bool, int] = False,
         aszarr: bool = False,
     ) -> Union[np.ndarray, zarr.Array]:
-        """Reads a boxed sections of the geotiff to a zarr/numpy array
+        """Reads a boxed sections of the geotiff to a zarr/numpy array.
 
         Args:
-            bBox (BBox): A bounding box
-            outer_points (Union[bool, int]): Takes an int (n) that gets extra n layers of points/pixels that directly surround the bBox. Defaults to False.
-            safe (bool): If True, returns a zarr array. If False, forces a returns as a numpy array by putting the data into memory.  Defaults to False.
-
-
+            bBox (BBox): A bounding box.
+            outer_points (Union[bool, int]): Takes an int (n) that gets extra n layers of points/pixels
+              that directly surround the bBox. Defaults to False.
+            aszarr (bool): If True, returns a zarr array. If False, forces a returns as a numpy array by
+              putting the data into memory. Defaults to False.
 
         Returns:
-            np.ndarray: zarr array of the geotiff file
+            np.ndarray: Zarr array of the geotiff file.
         """
         ((x_min, y_min), (x_max, y_max)) = self.get_int_box(
             bBox, outer_points=outer_points

--- a/geotiff/geotiff.py
+++ b/geotiff/geotiff.py
@@ -413,7 +413,7 @@ class GeoTiff:
     ) -> Tuple[np.ndarray, np.ndarray]:
         """Gets the 2d x coordinates and the 2d y coordinates.
 
-        WARNING: This cannot handel big arrays (zarr), so use with caution
+        WARNING: This cannot handle big arrays (Zarr). Proceed with caution.
 
         Args:
             bBox (Optional[BBox], optional): The bounding box to git the coordinates within.
@@ -441,7 +441,7 @@ class GeoTiff:
         raise TypeError(f"You must supply a valid bBox. You gave: {bBox}")
 
     def read(self) -> zarr.Array:
-        """Reads the contents of the geotiff to a zarr array.
+        """Reads the contents of the geotiff to a Zarr array.
 
         Returns:
             np.ndarray: Zarr array of the geotiff file.

--- a/geotiff/geotiff.py
+++ b/geotiff/geotiff.py
@@ -1,5 +1,5 @@
 """GeoTIFF reader and writer."""
-from typing import List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np  # type: ignore
 import zarr  # type: ignore
@@ -225,8 +225,14 @@ class GeoTiff:
         left_bottom = self._convert_coords(self.crs_code, 4326, self.tif_bBox[1])
         return (right_top, left_bottom)
 
-    def _get_crs_code(self, geotiff_metadata: dict) -> int:
+    def _get_crs_code(self, geotiff_metadata: Optional[dict]) -> int:
         temp_crs_code: Optional[int] = None
+
+        if geotiff_metadata is None:
+            raise UserDefinedGeoKeyError(
+                "Can't detect the crs. Use as_crs to manually specify it."
+            )
+
         if geotiff_metadata["GTModelTypeGeoKey"].value == 1:
             if hasattr(geotiff_metadata["ProjectedCSTypeGeoKey"], "value"):
                 temp_crs_code = geotiff_metadata["ProjectedCSTypeGeoKey"].value

--- a/geotiff/geotiff.py
+++ b/geotiff/geotiff.py
@@ -1,5 +1,5 @@
 """GeoTIFF reader and writer."""
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np  # type: ignore
 import zarr  # type: ignore
@@ -227,12 +227,10 @@ class GeoTiff:
 
     def _get_crs_code(self, geotiff_metadata: Optional[dict]) -> int:
         temp_crs_code: Optional[int] = None
+        crs_error_msg = "Can't detect the crs. Use as_crs to manually specify it."
 
         if geotiff_metadata is None:
-            raise UserDefinedGeoKeyError(
-                "Can't detect the crs. Use as_crs to manually specify it."
-            )
-
+            raise UserDefinedGeoKeyError(crs_error_msg)
         if geotiff_metadata["GTModelTypeGeoKey"].value == 1:
             if hasattr(geotiff_metadata["ProjectedCSTypeGeoKey"], "value"):
                 temp_crs_code = geotiff_metadata["ProjectedCSTypeGeoKey"].value
@@ -251,9 +249,7 @@ class GeoTiff:
         if temp_crs_code != 32767 and isinstance(temp_crs_code, int):
             return temp_crs_code
         elif temp_crs_code == 32767:
-            raise UserDefinedGeoKeyError(
-                "Can't detect the crs. Use as_crs to manually specify it."
-            )
+            raise UserDefinedGeoKeyError(crs_error_msg)
         else:
             raise GeographicTypeGeoKeyError()
 

--- a/geotiff/utils/__init__.py
+++ b/geotiff/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Helper module for geotiff package."""

--- a/geotiff/utils/crs_code_guess.py
+++ b/geotiff/utils/crs_code_guess.py
@@ -1,3 +1,4 @@
+"""CRS Guessing Module."""
 from difflib import SequenceMatcher
 from typing import List, Tuple
 
@@ -15,14 +16,13 @@ PreDict = List[Tuple[str, int]]
 
 
 def crs_code_gusser(GTCitationGeo: str) -> Tuple[int, float]:
-    """This is a very hacky solution to the problem of finding the correct
-    crs code based on the GTCitationGeoKey string.
+    """A very hacky solution to the problem of finding the correct crs code based on the GTCitationGeoKey string.
 
     Args:
-        GTCitationGeo (str): GT Citation Geo Key
+        GTCitationGeo (str): GT Citation Geo Key.
 
     Returns:
-        Tuple[int, float]: ([The crs code], [the score of the guess from 0 to 1])
+        Tuple[int, float]: ([The crs code], [the score of the guess from 0 to 1]).
     """
     crs_code: int = 32767
     projs: PreDict = [(name, member.value) for name, member in Proj.__members__.items()]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
-;[pydocstyle]
-;convention = numpy
-;match = ((?!(test_)).)*\.py
+[pydocstyle]
+convention = google
+match = ((?!(test_)).)*\.py
 
 [isort]
 profile = black

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     url="https://github.com/Open-Source-Agriculture/geotiff",
     packages=find_packages(),
     classifiers=[
+        "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
         "Natural Language :: English",
@@ -40,6 +41,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Topic :: Scientific/Engineering :: GIS",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     python_requires=">=3.7",
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup  # type: ignore
 from setuptools.command.egg_info import egg_info  # type: ignore
 from setuptools.command.install import install  # type: ignore
 
-VERSION = "0.2.9"
+VERSION = "0.2.10"
 
 # Send to pypi
 # python3 setup.py sdist bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+"""Setup."""
 from setuptools import find_packages, setup  # type: ignore
 from setuptools.command.egg_info import egg_info  # type: ignore
 from setuptools.command.install import install  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     python_requires=">=3.7",
     install_requires=requirements,


### PR DESCRIPTION
Closes #49

### Changes

* Updated pre-commit hooks to their newest versions, reordered them so that checks fail where they should.
* Enabled the `pydocstyle` pre-commit hook using Google docstring conventions.
* Added missing documentation to modules, classes, and methods
* Removed the `__init__.py` from `tests`. Tests are still installed, but is no longer treated as a package unto itself.
* Added some nicer-looking markdown warnings in README
* Added some classifiers to denote topic and development status
* Added Python3.11 support to classifiers and added a Python3.11 build to workflows