### PR TITLE
Add method to close file connection

### DIFF
--- a/geotiff/geotiff.py
+++ b/geotiff/geotiff.py
@@ -171,9 +171,9 @@ class GeoTiff:
         if not tif.geotiff_metadata:
             raise Exception("No Metadata")
 
-        store = tif.aszarr(key=band)
-        self._z = zarr.open(store, mode="r")
-        store.close()
+        self._store = tif.aszarr(key=band)
+        self._z = zarr.open(self._store, mode="r")
+        self._store.close()
         if isinstance(crs_code, int):
             self._crs_code: int = crs_code
         else:
@@ -481,3 +481,7 @@ class GeoTiff:
         if aszarr:
             return zarr.array(boxed_array)
         return np.array(boxed_array)
+
+    def close(self):
+        """Closes the geotiff file."""
+        self._store.close()


### PR DESCRIPTION
New method `.close()` closes any connection opened by e.g. `read_box`, to the ZarrTiffStore corresponding to the GeoTiff. Fixes #69.
```
>>> import geotiff
>>> import os
>>> geo_tiff = geotiff.GeoTiff('o41078a7.tif')
>>> geo_tiff.read()[:10,:10]
array([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
       [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
       [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
       [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
       [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
       [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
       [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
       [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
       [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
       [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]], dtype=uint8)
>>> os.remove('o41078a7.tif')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'o41078a7.tif'
>>> geo_tiff.close()
>>> os.remove('o41078a7.tif')
>>>
```